### PR TITLE
fix: lock singularity version to 3.8.6

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,7 +60,7 @@ jobs:
           pip install -r requirements.test.txt
       - name: Install singularity
         run: |
-          mamba install -c conda-forge -c bioconda singularity
+          mamba install -c conda-forge -c bioconda singularity=3.8.6
       - name: Integration test merge config, singularity
         working-directory: .tests/integration
         run: |


### PR DESCRIPTION
3.8.7 which is the latest version on conda are missing a library.

### Review and tests: 
- [ ] Tests pass
